### PR TITLE
[fix/profile-teacher-child-list] 선생님 회원의 자녀 목록이 노출되지 않는 현상 수정

### DIFF
--- a/src/stores/profileStore.ts
+++ b/src/stores/profileStore.ts
@@ -99,9 +99,12 @@ export const useProfileStore = create<ProfileState>()(
 
 				if (profileError) throw profileError;
 
-				// 부모인 경우 자녀 목록도 가져오기
+				// 부모 또는 선생님인 경우 자녀 목록도 가져오기
 				let childInfos: ChildInfo[] = [];
-				if (profileData.role === "parent") {
+				if (
+					profileData.role === "parent" ||
+					profileData.role === "teacher"
+				) {
 					try {
 						const { data: childLinks, error: childError } =
 							await supabase


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
선생님 프로필에서 자녀 목록이 노출되지 않는 현상을 수정하였습니다~

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
실제 자녀 테이블에는 들어가고 있었으나, profileData.role === "teacher" 일 경우에도 노출되는 조건이 빠져있어서 추가했습니다~

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
<img width="1381" height="850" alt="image" src="https://github.com/user-attachments/assets/5492e8db-0d7a-411e-ad8b-af956522884e" />

