### PR TITLE
[fix/register-social-childcode]소셜유저 프로필 설정 페이지에서 입력한 자녀코드가 실제 테이블에 입력되도록 수정

### DIFF
--- a/src/pages/auth/SocialSignupInfo.tsx
+++ b/src/pages/auth/SocialSignupInfo.tsx
@@ -191,6 +191,26 @@ export default function SocialSignupInfo() {
 				return;
 			}
 
+			// 부모-자녀 연결
+			if (role === "parent" && childLinkCode.trim()) {
+				const { data: childUser, error: searchError } = await supabase
+					.from("users")
+					.select("auth_id")
+					.eq("child_link_code", childLinkCode.trim())
+					.single();
+
+				if (!childUser || searchError) {
+					console.warn("자녀 코드 검색 실패", searchError);
+				} else {
+					await supabase.from("child_parent_links").insert([
+						{
+							parent_id: profile?.auth_id,
+							child_id: childUser.auth_id,
+						},
+					]);
+				}
+			}
+
 			// 프로필 새로고침
 			await fetchProfile();
 


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
소셜 유저 프로필 설정 페이지에서 입력한 자녀코드가 실제 테이블에 입력되도록 수정

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
소셜 유저의 필수 프로필 설정 페이지에서 입력한 자녀 코드가 실제로 DB에 부모-자녀 관계 테이블에 등록되지 않아서 해당 현상 수정했습니다

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
